### PR TITLE
feat: Add ability to indicate desired device pattern

### DIFF
--- a/src/ccstudiodss/api.py
+++ b/src/ccstudiodss/api.py
@@ -64,7 +64,7 @@ class Session:
     script = attr.ib(default=None)
     debug_server = attr.ib(default=None)
     debug_session = attr.ib(default=None)
-    device_string = attr.ib(default='.*')
+    device_pattern = attr.ib(default='.*')
 
     def __enter__(self):
         javabridge.start_vm(run_headless=True)
@@ -78,7 +78,7 @@ class Session:
             self.debug_server = self.script.getServer("DebugServer.1")
             self.debug_server.setConfig(ccstudiodss.utils.fspath(self.ccxml))
 
-            self.debug_session = self.debug_server.openSession(self.device_string)
+            self.debug_session = self.debug_server.openSession(self.device_pattern)
 
             self.debug_session.target.connect()
         except:

--- a/src/ccstudiodss/api.py
+++ b/src/ccstudiodss/api.py
@@ -64,6 +64,7 @@ class Session:
     script = attr.ib(default=None)
     debug_server = attr.ib(default=None)
     debug_session = attr.ib(default=None)
+    device_string = attr.ib(default='.*')
 
     def __enter__(self):
         javabridge.start_vm(run_headless=True)
@@ -77,7 +78,7 @@ class Session:
             self.debug_server = self.script.getServer("DebugServer.1")
             self.debug_server.setConfig(ccstudiodss.utils.fspath(self.ccxml))
 
-            self.debug_session = self.debug_server.openSession()
+            self.debug_session = self.debug_server.openSession(self.device_string)
 
             self.debug_session.target.connect()
         except:


### PR DESCRIPTION
Needed for TI Delfino dual core TMS320F28377D part.

If no parameters are given to openSession(), it defaults to '.*'.
On the dual core parts '.*' matches multiple device id's, so it fails to open the session.
To program CPU1 the device id string "Texas Instruments XDS100v2 USB Debug Probe/C28xx_CPU1" needs to be provided.
openSession("Texas Instruments XDS100v2 USB Debug Probe/C28xx_CPU1")
